### PR TITLE
Remove needless argument

### DIFF
--- a/media-thumbnail.el
+++ b/media-thumbnail.el
@@ -350,7 +350,6 @@ to disable automatic refresh when a special command is triggered."
                  (delay (cdr x)))
              (advice-remove
               command
-              :after
               (intern
                (format "media-thumbnail-refresh-after-%S"
                        command))))


### PR DESCRIPTION
`advice-remove` does not accept keyword argument. I got the following error when disabling ` media-thumbnail-dired-mode`

```
let: Wrong number of arguments: (2 . 2), 3
```